### PR TITLE
Fix intToBytes returning rgb instead of rgba

### DIFF
--- a/src/main/java/dan200/computercraft/client/render/text/DirectFixedWidthFontRenderer.java
+++ b/src/main/java/dan200/computercraft/client/render/text/DirectFixedWidthFontRenderer.java
@@ -220,8 +220,7 @@ public final class DirectFixedWidthFontRenderer
         // Require the pointer to be aligned to a 32-bit boundary.
         if( (addr & 3) != 0 ) throw new IllegalStateException( "Memory is not aligned" );
         // Also assert the length of the array. This appears to help elide bounds checks on the array in some circumstances.
-        // if rgb then rgba.length == 3 !!!
-        if( rgba.length != 3 && rgba.length != 4 ) throw new IllegalStateException();
+        if( rgba.length != 4 ) throw new IllegalStateException();
 
         memPutFloat( addr + 0, x1 );
         memPutFloat( addr + 4, y1 );

--- a/src/main/java/dan200/computercraft/core/apis/TermAPI.java
+++ b/src/main/java/dan200/computercraft/core/apis/TermAPI.java
@@ -5,7 +5,6 @@
  */
 package dan200.computercraft.core.apis;
 
-import dan200.computercraft.api.lua.IArguments;
 import dan200.computercraft.api.lua.ILuaAPI;
 import dan200.computercraft.api.lua.LuaException;
 import dan200.computercraft.api.lua.LuaFunction;

--- a/src/main/java/dan200/computercraft/shared/util/ColourUtils.java
+++ b/src/main/java/dan200/computercraft/shared/util/ColourUtils.java
@@ -54,7 +54,7 @@ public final class ColourUtils
         byte g = (byte)(rgb >> 8);
         byte r = (byte)(rgb >> 16);
 
-        return new byte[] { r, g, b, 255 };
+        return new byte[] { r, g, b, (byte)255 };
     }
 
     public static int bytesToInt( byte[] rgb )

--- a/src/main/java/dan200/computercraft/shared/util/ColourUtils.java
+++ b/src/main/java/dan200/computercraft/shared/util/ColourUtils.java
@@ -54,7 +54,7 @@ public final class ColourUtils
         byte g = (byte)(rgb >> 8);
         byte r = (byte)(rgb >> 16);
 
-        return new byte[] { r, g, b };
+        return new byte[] { r, g, b, 255 };
     }
 
     public static int bytesToInt( byte[] rgb )


### PR DESCRIPTION
dan200.computercraft.client.render.text.DirectFixedWidthFontRenderer.quad uses rgba values and not just rgb, might be other uses like that so i changed it in the root